### PR TITLE
Add missing "types" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "description": "A vue-class-component decorator for vue-async-computed",
   "module": "src/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "check": "npm run lint -s && npm run test -s",
     "lint": "eslint src",


### PR DESCRIPTION
Hi @foxbenjaminfox. I just added mising `"types": "types/index.d.ts",` to `package.json`.

If none, I have the following error.
![image](https://user-images.githubusercontent.com/10933561/71535335-8260fd80-2948-11ea-9fdd-4bed0afef7ec.png)
