### PR TITLE
Add missing "default" to the type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
 import { IAsyncComputedValue } from 'vue-async-computed';
 import { VueDecorator } from 'vue-class-component';
 
-export function AsyncComputed<T>(computedOptions?: IAsyncComputedValue<T>): VueDecorator;
+export default function AsyncComputed<T>(computedOptions?: IAsyncComputedValue<T>): VueDecorator;


### PR DESCRIPTION
Hi @foxbenjaminfox, thank you very much for the release.

I just added missing `default` to `types/index.d.ts`.
If none, you will have the following error: "This expression is not callable."
![image](https://user-images.githubusercontent.com/10933561/71550878-b8bc7c80-2a1d-11ea-8716-35628f50b5c4.png)
